### PR TITLE
Cash at bank time steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/__pycache__/
 /.vscode/
 **/database.db
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@
 ## Installation
 With a terminal in the directory of the project run the following commands.
 
+### Windows
 ```cmd
 python -m venv venv
 call venv\Scripts\activate
 pip install -r requirements.txt
-python database/create.py
+```
+
+### MacOS
+```cmd
+python -m venv venv
+source venv/bin/activate
+pip install - r requirements.txt
 ```
 
 ## Game Idea

--- a/core_data/the_bank.py
+++ b/core_data/the_bank.py
@@ -4,9 +4,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import create_engine, Session
 
 from database.create import DB_URL
-from database.models import Ledger
+from database.models import Ledger, CashAtBank
 from detailed_records.capital import Capital
-from detailed_records.cash_at_bank import CashAtBank
+from detailed_records.cash_at_bank import cash_at_bank
 from utils.logging import log_config
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class Bank:
         self.capital = None
 
     def establish_bank(self, settings):
-        self.cash_at_bank = CashAtBank(settings)
+        self.cash_at_bank = cash_at_bank()
         self.capital = Capital(settings)
         initial_investment = settings.initial_investment
         capital_premium_ratio = settings.capital_premium_ratio
@@ -32,6 +32,7 @@ class Bank:
             session.add_all(
                 [
                     Ledger(date=start_date, bs_account="Bank of England Reserve Account", amount=-initial_investment),
+                    CashAtBank(counterparty="Bank of England", principal=initial_investment, accrued_interest=0, interest_rate=0.0400),
                     Ledger(
                         date=start_date, bs_account="Paid Up Share Capital",
                         amount=(initial_investment * capital_premium_ratio)

--- a/database/chart_of_accounts.json
+++ b/database/chart_of_accounts.json
@@ -16,5 +16,17 @@
     "bs_category": "Equity",
     "bs_class": "Share Premium",
     "bs_account": "Share Premium"
+  },
+  {
+    "sort_order": 4,
+    "bs_category": "Equity",
+    "bs_class": "Income",
+    "bs_account": "BofE Interest Income"
+  },
+  {
+    "sort_order": 5,
+    "bs_category": "Assets",
+    "bs_class": "Interest Receivables",
+    "bs_account": "BofE Interest Receivable"
   }
 ]

--- a/database/create.py
+++ b/database/create.py
@@ -1,11 +1,12 @@
 import json
 import logging
+from inspect import isclass
 from pathlib import Path
 
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import create_engine, Session, SQLModel
 
-from database.models import BalanceSheet, ChartOfAccounts, Ledger
+from database.models import BalanceSheet, ChartOfAccounts, Ledger, CashAtBank
 from utils.logging import log_config
 
 DB_PATH = Path(__file__).parent / "data" / "database.db"
@@ -20,7 +21,7 @@ def create_coa() -> None:
     Function to create the chart of accounts from the json file. This should only happen
     on the initial creation of the database.
     """
-    with open("database\chart_of_accounts.json", "r") as f:
+    with open("database/chart_of_accounts.json", "r") as f:
         coa = json.load(f)
 
     engine = create_engine(DB_URL)
@@ -34,8 +35,12 @@ def create_coa() -> None:
         except IntegrityError as e:
             logger.error(f"Error creating chart of accounts: {e}")
 
-def create_db():
-    models = [BalanceSheet, Ledger, ChartOfAccounts]
+
+def create_db() -> None:
+    """
+    Function to create the database file
+    """
+    models = [BalanceSheet, Ledger, ChartOfAccounts, CashAtBank]
 
     # Create path if it doesn't exist:
     if not DB_PATH.parent.exists():

--- a/database/models.py
+++ b/database/models.py
@@ -21,3 +21,9 @@ class ChartOfAccounts(SQLModel, table=True):
     bs_class: str = Field(index=True)
     bs_account: str = Field(primary_key=True)
     sort_order: int
+
+class CashAtBank(SQLModel, table=True):
+    counterparty: str = Field(primary_key=True, unique=True)
+    principal: float
+    accrued_interest: float
+    interest_rate: float

--- a/detailed_records/cash_at_bank.py
+++ b/detailed_records/cash_at_bank.py
@@ -23,20 +23,16 @@ class cash_at_bank:
         return new_accrued_interest
 
     def time_step(self) -> None:
-        "Advances the data by 1 day"
-        sql = "SELECT * FROM CashAtBank"
-        conn = sqlite3.connect("database/data/database.db")
-        df = pd.read_sql(sql,conn)
+        """ Advances the data by 1 day, post's changes to ledger """
+        engine = create_engine(DB_URL)
 
-        delete = 'DELETE FROM CashAtBank'
-        cur = conn.cursor()
-        cur.execute(delete)
-        conn.commit()
+        sql = "SELECT * FROM CashAtBank"
+        df = pd.read_sql(sql,engine)
         
-        #Accrued Interest
+        # Accrued Interest
         # TODO: Handle interest payment
         df['accrued_interest'] = df.apply(self.accrued_interest_time_step, axis=1)
 
+        # Export Changes
         # TODO: Post changes to ledger
-        engine = create_engine(DB_URL)
-        df.to_sql("CashAtBank", engine, if_exists="append", index=False)
+        df.to_sql("cashatbank", engine, if_exists="replace", index=False)

--- a/detailed_records/cash_at_bank.py
+++ b/detailed_records/cash_at_bank.py
@@ -3,6 +3,7 @@ import pandas as pd
 import sqlite3
 import datetime as dt
 from sqlmodel import create_engine, Session
+from sqlalchemy.exc import IntegrityError
 
 from database.create import DB_URL 
 from database.models import Ledger, CashAtBank

--- a/detailed_records/cash_at_bank.py
+++ b/detailed_records/cash_at_bank.py
@@ -1,8 +1,10 @@
 import logging
 import pandas as pd
 import sqlite3
+from sqlmodel import create_engine
 
-from database.create import DB_URL
+from database.create import DB_URL 
+from database.models import Ledger, CashAtBank
 
 from utils.logging import log_config
 
@@ -14,24 +16,27 @@ class cash_at_bank:
     def __init__(self):
         pass
 
-    def accrued_interest_time_step(self, df, index, row) -> pd.DataFrame:
+    def accrued_interest_time_step(self, row) -> pd.DataFrame.apply:
         """ Handles accrued interest component of time stepping """
-        accrued_interest = row['accrued_interest']
         accrued_interest_generated = (row['principal'] * row['interest_rate']) / 360
-        new_accrued_interest = accrued_interest + accrued_interest_generated
-        df.loc[index, 'accrued_interest'] = new_accrued_interest
-        return df
+        new_accrued_interest = row['accrued_interest'] + accrued_interest_generated
+        return new_accrued_interest
 
     def time_step(self) -> None:
         "Advances the data by 1 day"
         sql = "SELECT * FROM CashAtBank"
         conn = sqlite3.connect("database/data/database.db")
-        df_org = pd.read_sql(sql,conn)
+        df = pd.read_sql(sql,conn)
+
+        delete = 'DELETE FROM CashAtBank'
+        cur = conn.cursor()
+        cur.execute(delete)
+        conn.commit()
         
         #Accrued Interest
         # TODO: Handle interest payment
-        for index, row in df_org.iterrows():
-            df_new = self.accrued_interest_time_step(df_org, index, row)
-        print(df_new)
-        
+        df['accrued_interest'] = df.apply(self.accrued_interest_time_step, axis=1)
+
         # TODO: Post changes to ledger
+        engine = create_engine(DB_URL)
+        df.to_sql("CashAtBank", engine, if_exists="append", index=False)

--- a/detailed_records/cash_at_bank.py
+++ b/detailed_records/cash_at_bank.py
@@ -1,7 +1,8 @@
 import logging
 import pandas as pd
 import sqlite3
-from sqlmodel import create_engine
+import datetime as dt
+from sqlmodel import create_engine, Session
 
 from database.create import DB_URL 
 from database.models import Ledger, CashAtBank
@@ -22,17 +23,44 @@ class cash_at_bank:
         new_accrued_interest = row['accrued_interest'] + accrued_interest_generated
         return new_accrued_interest
 
-    def time_step(self) -> None:
+    def ledger_postings(self, old, new, date) -> None:
+        """ Takes two cash at bank dataframes and calculates the differnces then posts to the ledger """
+        engine = create_engine(DB_URL)
+
+        principal_change = new['principal'].sum() - old['principal'].sum()
+        accrued_interest_change = new['accrued_interest'].sum() - old['accrued_interest'].sum()
+        # TODO: Add calc for interest payments
+
+        # TODO: Handle Global dates
+        with Session(engine) as session:
+            session.add_all(
+                [
+                    Ledger(date=date, bs_account="Bank of England Reserve Account", amount=principal_change),
+                    Ledger(date=date, bs_account="BofE Interest Income", amount=accrued_interest_change),
+                    Ledger(date=date, bs_account="BofE Interest Receivable", amount=accrued_interest_change)
+                ]
+            )
+            try:
+                session.commit()
+                logger.info(f"Cash at Bank ledger entries created for {date}")
+            except IntegrityError as e:
+                logger.error(f"Error creating cash at bank ledger entries: {e}")
+
+
+    def time_step(self, date) -> None:
         """ Advances the data by 1 day, post's changes to ledger """
         engine = create_engine(DB_URL)
 
         sql = "SELECT * FROM CashAtBank"
         df = pd.read_sql(sql,engine)
+        df_new = df
         
         # Accrued Interest
         # TODO: Handle interest payment
-        df['accrued_interest'] = df.apply(self.accrued_interest_time_step, axis=1)
+        df_new['accrued_interest'] = df_new.apply(self.accrued_interest_time_step, axis=1)
 
         # Export Changes
+        df_new.to_sql("cashatbank", engine, if_exists="replace", index=False)
+
         # TODO: Post changes to ledger
-        df.to_sql("cashatbank", engine, if_exists="replace", index=False)
+        self.ledger_postings(df, df_new, date)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import logging
 from utils.logging import log_config
+import datetime as dt
 
 from gamestate import GameState
 from settings import Settings
@@ -32,6 +33,10 @@ testing_output.balance_sheet_summary()
 testing_output.ledger_summary()
 testing_output.cash_at_bank_summary()
 
+date = dt.date(2020, 1, 1)
 for _ in range(5):
-    game.bank.cash_at_bank.time_step()
+    date += dt.timedelta(days=1)
+    game.bank.cash_at_bank.time_step(date)
+    testing_output.balance_sheet_summary()
+    testing_output.ledger_summary()
     testing_output.cash_at_bank_summary()

--- a/main.py
+++ b/main.py
@@ -31,4 +31,7 @@ logger.info("Bank Established")
 testing_output.balance_sheet_summary()
 testing_output.ledger_summary()
 testing_output.cash_at_bank_summary()
-game.bank.cash_at_bank.time_step()
+
+for _ in range(5):
+    game.bank.cash_at_bank.time_step()
+    testing_output.cash_at_bank_summary()

--- a/main.py
+++ b/main.py
@@ -30,3 +30,5 @@ logger.info("Bank Established")
 
 testing_output.balance_sheet_summary()
 testing_output.ledger_summary()
+testing_output.cash_at_bank_summary()
+game.bank.cash_at_bank.time_step()

--- a/testing_output.py
+++ b/testing_output.py
@@ -3,13 +3,15 @@ from utils.logging import log_config
 import sqlite3
 import pandas as pd
 
+from database.create import DB_PATH
+
 logger = logging.getLogger(__name__)
 logger = log_config(logger)
 
 def balance_sheet_summary() -> None:
     "Prints to log various summary statistics on the balance sheet"
     sql = "SELECT * FROM BalanceSheet"
-    conn = sqlite3.connect("database/data/database.db")
+    conn = sqlite3.connect(DB_PATH)
     df = pd.read_sql(sql,conn)
     logger.info("Balance Sheet Summary")
     logger.info("---------------------")
@@ -25,7 +27,7 @@ def balance_sheet_summary() -> None:
 def ledger_summary() -> None:
     "Prints to log various summary statistics on the ledger"
     sql = "SELECT * FROM Ledger"
-    conn = sqlite3.connect("database/data/database.db")
+    conn = sqlite3.connect(DB_PATH)
     df = pd.read_sql(sql,conn)
     postings = len(df.index)
     value = df["amount"].sum()
@@ -33,3 +35,15 @@ def ledger_summary() -> None:
     logger.info(f"Total postings to ledger - {postings}")
     logger.info(f"Total value of postings to ledger - {value}, should always be 0")
     logger.info(f"Total absolute value of postings to ledger - {abs_value}")
+
+def cash_at_bank_summary() -> None:
+    """ Prints to log various summary statistics on cash at bank """
+    sql = "SELECT * FROM CashAtBank"
+    conn = sqlite3.connect(DB_PATH)
+    df = pd.read_sql(sql,conn)
+    deals = len(df.index)
+    principal = df["principal"].sum()
+    accrued_interest = df["accrued_interest"].sum()
+    logger.info(f"Total Deals in cash at bank - {deals}")
+    logger.info(f"Total Principal in cash at bank - {principal}")
+    logger.info(f"Total Accrued Interest in cash at bank - {accrued_interest}")


### PR DESCRIPTION
Initial versions of timestepping concepts in cash at bank setting the framework for future detailed areas

please review
- Reading agreements into a df to do handling rather than passing SQL directly (Note did this as you need to calculate balance difs for ledger postings)
- docs hints

Please Ignore
- Poor data handling, next dev branch will be global date handling through the DB
- Naming conventions (found an issue with capitalised table names [here](https://stackoverflow.com/questions/59389911/sqlalchemy-exc-invalidrequesterror-could-not-reflect-requested-tables-not-av) will look to update names across the board soon
- The fact that interest accruals can't be reversed. Once date handling is done then interest payment will be and the postings will be added for moving interest to principal.